### PR TITLE
Make DAO base class extensible

### DIFF
--- a/storm-apt/api/src/main/java/com/turbomanage/storm/api/Entity.java
+++ b/storm-apt/api/src/main/java/com/turbomanage/storm/api/Entity.java
@@ -15,6 +15,8 @@
  ******************************************************************************/
 package com.turbomanage.storm.api;
 
+import com.turbomanage.storm.SQLiteDao;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -33,5 +35,5 @@ public @interface Entity {
 
 	String dbName() default "";
 	String name() default "";
-
+	Class<? extends SQLiteDao> baseDaoClass() default SQLiteDao.class;
 }

--- a/storm-apt/impl/src/main/java/com/turbomanage/storm/apt/BaseDaoModel.java
+++ b/storm-apt/impl/src/main/java/com/turbomanage/storm/apt/BaseDaoModel.java
@@ -1,0 +1,24 @@
+package com.turbomanage.storm.apt;
+
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Class representing the Base Dao Class
+ * <p/>
+ *
+ * @Author Alexander Gherschon
+ */
+public class BaseDaoModel extends ClassModel {
+
+    /**
+     * Base Dao Class is received from the Annotation as TypeMirror
+     *
+     * @param typeMirror
+     */
+    public BaseDaoModel(TypeMirror typeMirror) {
+
+        String qualifiedName = typeMirror.toString();
+        setClassName(qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1));
+        setPackageName(qualifiedName.substring(0, qualifiedName.lastIndexOf(".")));
+    }
+}

--- a/storm-apt/impl/src/main/java/com/turbomanage/storm/apt/entity/EntityModel.java
+++ b/storm-apt/impl/src/main/java/com/turbomanage/storm/apt/entity/EntityModel.java
@@ -17,6 +17,7 @@ package com.turbomanage.storm.apt.entity;
 
 import com.turbomanage.storm.SQLiteDao;
 import com.turbomanage.storm.api.Entity;
+import com.turbomanage.storm.apt.BaseDaoModel;
 import com.turbomanage.storm.apt.ClassModel;
 import com.turbomanage.storm.apt.database.DatabaseModel;
 
@@ -26,7 +27,7 @@ public class EntityModel extends ClassModel {
 	private static final String TABLE_SUFFIX = "Table";
 	static final String DEFAULT_ID_FIELD = "id";
 	static final String ID_COL = "_id";
-	private Class<SQLiteDao> baseDaoClass;
+	private BaseDaoModel baseDaoClass;
 	private DatabaseModel dbModel;
 	private String dbName;
 	private String tableName;
@@ -62,17 +63,17 @@ public class EntityModel extends ClassModel {
 	 * @return String Simple name of the base DAO
 	 */
 	public String getBaseDaoName() {
-		return this.baseDaoClass.getSimpleName();
+		return this.baseDaoClass.getClassName();
 	}
 
-	protected Class<SQLiteDao> getBaseDaoClass() {
+	protected BaseDaoModel getBaseDaoClass() {
 		return baseDaoClass;
 	}
 
-	protected void setBaseDaoClass(Class<SQLiteDao> daoClass) {
+	protected void setBaseDaoClass(BaseDaoModel daoClass) {
 		this.baseDaoClass = daoClass;
 		// add corresponding import
-		this.addImport(daoClass.getCanonicalName());
+		this.addImport(daoClass.getQualifiedClassName());
 	}
 
 	void setDatabase(DatabaseModel dbModel) {

--- a/storm-apt/impl/src/main/java/com/turbomanage/storm/apt/entity/EntityProcessor.java
+++ b/storm-apt/impl/src/main/java/com/turbomanage/storm/apt/entity/EntityProcessor.java
@@ -24,12 +24,14 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import com.turbomanage.storm.SQLiteDao;
 import com.turbomanage.storm.api.Entity;
 import com.turbomanage.storm.api.Id;
+import com.turbomanage.storm.apt.BaseDaoModel;
 import com.turbomanage.storm.apt.ClassProcessor;
 import com.turbomanage.storm.apt.SqlUtil;
 import com.turbomanage.storm.apt.StormEnvironment;
@@ -39,144 +41,165 @@ import com.turbomanage.storm.exception.TypeNotSupportedException;
 
 public class EntityProcessor extends ClassProcessor {
 
-	private static final String TAG = EntityProcessor.class.getName();
-	private EntityModel entityModel;
+    private static final String TAG = EntityProcessor.class.getName();
+    private EntityModel entityModel;
 
-	public EntityProcessor(Element el, StormEnvironment stormEnv) {
-		super(el, stormEnv);
-	}
+    public EntityProcessor(Element el, StormEnvironment stormEnv) {
+        super(el, stormEnv);
+    }
 
-	@Override
-	public EntityModel getModel() {
-		return this.entityModel;
-	}
+    @Override
+    public EntityModel getModel() {
+        return this.entityModel;
+    }
 
-	@Override
-	public void populateModel() {
-		// TODO make more elegant
-		Entity entity = this.typeElement.getAnnotation(Entity.class);
-		if (entity != null) {
-			this.entityModel = new EntityModel(entity);
-		} else {
-			javax.persistence.Entity jpaEntity = this.typeElement.getAnnotation(javax.persistence.Entity.class);
-			if (jpaEntity != null) {
-				this.entityModel = new EntityModel(jpaEntity);
-			}
-		}
-		super.populateModel();
-		this.entityModel.addImport(getQualifiedClassName());
-		validateTableName(entityModel.getTableName());
-		chooseDatabase(entityModel.getDbName());
-		chooseBaseDao(entity);
-		readFields(typeElement);
-		inspectId();
-		// TODO Verify >1 column. If only ID col, insert() will fail
-	}
+    @Override
+    public void populateModel() {
+        // TODO make more elegant
+        Entity entity = this.typeElement.getAnnotation(Entity.class);
+        if (entity != null) {
+            this.entityModel = new EntityModel(entity);
+        } else {
+            javax.persistence.Entity jpaEntity = this.typeElement.getAnnotation(javax.persistence.Entity.class);
+            if (jpaEntity != null) {
+                this.entityModel = new EntityModel(jpaEntity);
+            }
+        }
+        super.populateModel();
+        this.entityModel.addImport(getQualifiedClassName());
+        validateTableName(entityModel.getTableName());
+        chooseDatabase(entityModel.getDbName());
+        chooseBaseDao(entity);
+        readFields(typeElement);
+        inspectId();
+        // TODO Verify >1 column. If only ID col, insert() will fail
+    }
 
-	private void validateTableName(String tableName) {
-		if (tableName != null && tableName.length() > 0) {
-			this.entityModel.setTableName(tableName);
-		} else {
-			this.entityModel.setTableName(getClassName());
-		}
-		if (!SqlUtil.isValidIdentifier(this.entityModel.getTableName())) {
-			abort(tableName + " is not a valid identifier. Enclose SQL keywords with [].");
-		}
-	}
+    private void validateTableName(String tableName) {
+        if (tableName != null && tableName.length() > 0) {
+            this.entityModel.setTableName(tableName);
+        } else {
+            this.entityModel.setTableName(getClassName());
+        }
+        if (!SqlUtil.isValidIdentifier(this.entityModel.getTableName())) {
+            abort(tableName + " is not a valid identifier. Enclose SQL keywords with [].");
+        }
+    }
 
-	protected void chooseBaseDao(Entity entity) {
-//		List<String> iNames = super.inspectInterfaces();
-//		if (iNames.contains(Persistable.class.getName())) {
-		this.entityModel.setBaseDaoClass(SQLiteDao.class);
-	}
+    protected void chooseBaseDao(Entity entity) {
+        BaseDaoModel baseDao = getBaseDaoClass(entity);
+        this.entityModel.setBaseDaoClass(baseDao);
+    }
 
-	protected void chooseDatabase(String dbName) {
-		DatabaseModel defaultDb = stormEnv.getDefaultDb();
-		if (dbName != null &&  dbName.length() > 0) {
-			// Add db to entity model and vice versa
-			DatabaseModel db = stormEnv.getDbByName(dbName);
-			if (db != null) {
-				this.entityModel.setDatabase(db);
-			} else {
-				abort("There is no @Database named " + dbName);
-			}
-		} else if (defaultDb != null) {
-			this.entityModel.setDatabase(defaultDb);
-		} else {
-			abort("You must define at least one @Database");
-		}
-	}
+    protected void chooseDatabase(String dbName) {
+        DatabaseModel defaultDb = stormEnv.getDefaultDb();
+        if (dbName != null && dbName.length() > 0) {
+            // Add db to entity model and vice versa
+            DatabaseModel db = stormEnv.getDbByName(dbName);
+            if (db != null) {
+                this.entityModel.setDatabase(db);
+            } else {
+                abort("There is no @Database named " + dbName);
+            }
+        } else if (defaultDb != null) {
+            this.entityModel.setDatabase(defaultDb);
+        } else {
+            abort("You must define at least one @Database");
+        }
+    }
 
-	@Override
-	protected void inspectField(VariableElement field) {
-		Set<Modifier> modifiers = field.getModifiers();
-		boolean hasId = (field.getAnnotation(Id.class) != null);
+    @Override
+    protected void inspectField(VariableElement field) {
+        Set<Modifier> modifiers = field.getModifiers();
+        boolean hasId = (field.getAnnotation(Id.class) != null);
         String fieldName = field.getSimpleName().toString();
         if (!SqlUtil.isValidIdentifier(field.getSimpleName().toString())) {
             abort(fieldName + " is not a valid SQL column name.");
         }
-		if (!modifiers.contains(Modifier.TRANSIENT) && !modifiers.contains(Modifier.STATIC)) {
-			String javaType = getFieldType(field);
-			if (TypeKind.DECLARED.equals(field.asType().getKind())) {
-				DeclaredType type = (DeclaredType) field.asType();
-				TypeElement typeElement = (TypeElement) type.asElement();
-				TypeMirror superclass = typeElement.getSuperclass();
-				if (ElementKind.ENUM.equals(typeElement.getKind())) {
-					if (hasId) {
-						abort("@Id invalid on enums", field);
-					} else {
-						FieldModel fm = new FieldModel(field.getSimpleName().toString(), javaType, true, stormEnv.getConverterForType("java.lang.Enum"));
-						entityModel.addField(fm);
-					}
-					return;
-				}
-			}
-			// Verify supported type
-			try {
-				ConverterModel converter = stormEnv.getConverterForType(javaType);
-				FieldModel f = new FieldModel(field.getSimpleName().toString(), javaType, false, converter);
-				if (hasId) {
-					if (entityModel.getIdField() == null) {
-						if ("long".equals(f.getJavaType())) {
-							entityModel.setIdField(f);
-						} else {
-							abort("@Id field must be of type long", field);
-						}
-					} else {
-						abort("Duplicate @Id", field);
-					}
-				}
-				entityModel.addField(f);
-			} catch (TypeNotSupportedException e) {
-				stormEnv.getLogger().error(TAG + "inspectField", e, field);
-			} catch (Exception e) {
-				stormEnv.getLogger().error(TAG, e, field);
-			}
-			// TODO verify getter + setter
-		} else if (hasId) {
-			abort("@Id fields cannot be transient", field);
-		}
-	}
+        if (!modifiers.contains(Modifier.TRANSIENT) && !modifiers.contains(Modifier.STATIC)) {
+            String javaType = getFieldType(field);
+            if (TypeKind.DECLARED.equals(field.asType().getKind())) {
+                DeclaredType type = (DeclaredType) field.asType();
+                TypeElement typeElement = (TypeElement) type.asElement();
+                TypeMirror superclass = typeElement.getSuperclass();
+                if (ElementKind.ENUM.equals(typeElement.getKind())) {
+                    if (hasId) {
+                        abort("@Id invalid on enums", field);
+                    } else {
+                        FieldModel fm = new FieldModel(field.getSimpleName().toString(), javaType, true, stormEnv.getConverterForType("java.lang.Enum"));
+                        entityModel.addField(fm);
+                    }
+                    return;
+                }
+            }
+            // Verify supported type
+            try {
+                ConverterModel converter = stormEnv.getConverterForType(javaType);
+                FieldModel f = new FieldModel(field.getSimpleName().toString(), javaType, false, converter);
+                if (hasId) {
+                    if (entityModel.getIdField() == null) {
+                        if ("long".equals(f.getJavaType())) {
+                            entityModel.setIdField(f);
+                        } else {
+                            abort("@Id field must be of type long", field);
+                        }
+                    } else {
+                        abort("Duplicate @Id", field);
+                    }
+                }
+                entityModel.addField(f);
+            } catch (TypeNotSupportedException e) {
+                stormEnv.getLogger().error(TAG + "inspectField", e, field);
+            } catch (Exception e) {
+                stormEnv.getLogger().error(TAG, e, field);
+            }
+            // TODO verify getter + setter
+        } else if (hasId) {
+            abort("@Id fields cannot be transient", field);
+        }
+    }
 
-	/**
-	 * Verifies that the entity has exactly one id field of type long. 
-	 */
-	private void inspectId() {
-		if (entityModel.getIdField() == null) {
-			// Default to field named "id"
-			List<FieldModel> fields = entityModel.getFields();
-			for (FieldModel f : fields) {
-				if (EntityModel.DEFAULT_ID_FIELD.equals(f.getFieldName())) {
-					entityModel.setIdField(f);
-				}
-			}
-		}
-		FieldModel idField = entityModel.getIdField();
-		if (idField != null && "long".equals(idField.getJavaType())) {
-			return;
-		} else {
-			abort("Entity must contain a field named id or annotated with @Id of type long");
-		}
-	}
+    /**
+     * Verifies that the entity has exactly one id field of type long.
+     */
+    private void inspectId() {
+        if (entityModel.getIdField() == null) {
+            // Default to field named "id"
+            List<FieldModel> fields = entityModel.getFields();
+            for (FieldModel f : fields) {
+                if (EntityModel.DEFAULT_ID_FIELD.equals(f.getFieldName())) {
+                    entityModel.setIdField(f);
+                }
+            }
+        }
+        FieldModel idField = entityModel.getIdField();
+        if (idField != null && "long".equals(idField.getJavaType())) {
+            return;
+        } else {
+            abort("Entity must contain a field named id or annotated with @Id of type long");
+        }
+    }
 
+    /**
+     * Trying to get Class<?> from an annotation raises an exception
+     * see http://stackoverflow.com/questions/7687829/java-6-annotation-processing-getting-a-class-from-an-annotation
+     */
+    private static TypeMirror getBaseDaoTypeMirror(Entity entity) {
+        try {
+            entity.baseDaoClass();
+        } catch (MirroredTypeException mte) {
+            return mte.getTypeMirror();
+        }
+        return null;
+    }
+
+    /**
+     * Builds a BaseDaoModel from the class passed as attribute baseDaoClass of the annotation Entity
+     * @param entity
+     * @return BaseDaoModel containing the package name + Class name
+     */
+    private static BaseDaoModel getBaseDaoClass(Entity entity) {
+        TypeMirror typeMirror = getBaseDaoTypeMirror(entity);
+        return new BaseDaoModel(typeMirror);
+    }
 }


### PR DESCRIPTION
Implementation of a baseDaoClass attribute on the Entity annotation to be able to extend the class.
Fixes #21 

Example of use: 

@Entity(baseDaoClass = ReportSqlDao.class)
public class CallReport {
}
